### PR TITLE
Optimized Tokenize function

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ tok.MinWordSize = 3
 // set default stop words
 tok.DefaultStopWordFunc = IsGermanStopWord
 
-reuslt := tok.TokenizeV2("mailto://www.Subdomain.example.com/HSV-fussbal%3asome/a")
+reuslt := tok.TokenizeV3("mailto://www.Subdomain.example.com/HSV-fussbal%3asome/a")
 // custom stop words
-reuslt2 := tok.TokenizeV2("mailto://www.Subdomain.example.com/HSV-fussball%3asome/a", func(val string) bool {
+reuslt2 := tok.TokenizeV3("mailto://www.Subdomain.example.com/HSV-fussball%3asome/a", func(val string) bool {
 	if val == "fussball" {
 		return true
 	}
@@ -31,11 +31,20 @@ reuslt2 := tok.TokenizeV2("mailto://www.Subdomain.example.com/HSV-fussball%3asom
 ```
 # Benchmark Results
 
-goos: darwin
+goos: linux
 goarch: amd64
-cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
-|Benchmark|runs|time/op|B/op|allocs/op|
-|---|---|---|---|---|
-BenchmarkURLTokenizerV2-12|2026138|605.3 ns/op|256 B/op|1 allocs/op
-BenchmarkURLTokenizerV2Fast-12|3609961|330.6 ns/op|256 B/op|1 allocs/op
-BenchmarkURLTokenizerV1-12|1766235|676.3 ns/op|272 B/op|2 allocs/op
+pkg: github.com/emetriq/gourltokenizer/tokenizer
+cpu: 11th Gen Intel(R) Core(TM) i5-11500H @ 2.90GHz
+| Benchmark                         | runs    | time/op     | B/op     | allocs/op   |
+|-----------------------------------|---------|-------------|----------|-------------|
+| BenchmarkEscapedURLTokenizerV3-12 | 1000000 | 1080 ns/op  | 496 B/op | 3 allocs/op |
+| BenchmarkURLTokenizerV3-12        | 4751826 | 255.5 ns/op | 256 B/op | 1 allocs/op |
+| BenchmarkURLTokenizerV3Fast-12    | 6231590 | 191.6 ns/op | 256 B/op | 1 allocs/op |
+| BenchmarkEscapedURLTokenizerV2-12 | 1000000 | 1042 ns/op  | 496 B/op | 3 allocs/op |
+| BenchmarkURLTokenizerV2-12        | 3813273 | 484.2 ns/op | 256 B/op | 1 allocs/op |
+| BenchmarkURLTokenizerV2Fast-12    | 5835351 | 199.6 ns/op | 256 B/op | 1 allocs/op |
+| BenchmarkEscapedURLTokenizerV1-12 | 1942860 | 1084 ns/op  | 496 B/op | 3 allocs/op |
+| BenchmarkURLTokenizerV1-12        | 2495599 | 510.7 ns/op | 272 B/op | 2 allocs/op |
+| BenchmarkTokenizerV1-12           | 9431893 | 122.9 ns/op | 256 B/op | 1 allocs/op |
+| BenchmarkTokenizerV2-12           | 7669710 | 157.0 ns/op | 256 B/op | 1 allocs/op |
+| BenchmarkTokenizerV3-12           | 8120326 | 158.3 ns/op | 256 B/op | 1 allocs/op |

--- a/tokenizer/tokenizer.go
+++ b/tokenizer/tokenizer.go
@@ -10,11 +10,66 @@ var MinWordSize = 3
 
 var DefaultStopWordFunc = IsEnglishStopWord
 
+func isByteAllowed(b byte, isDotCountMode bool) bool {
+	if b >= 'a' && b <= 'z' {
+		return true
+	}
+	return isDotCountMode && b != '.' && b != '/'
+}
+
 func isRuneAllowed(r rune, isDotCountMode bool) bool {
 	if r >= 'a' && r <= 'z' {
 		return true
 	}
 	return isDotCountMode && r != '.' && r != '/'
+}
+
+// faster solution than using strings.Contains(), because we are only looking
+// for a single char and can leave the loop after
+func stringContainsByteChar(s string, r byte) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] == r {
+			return true
+		}
+	}
+	return false
+}
+
+// TokenizeV3 splits URL to host and path parts and tokenize path and host part
+// all terms are returned in lower case
+func TokenizeV3(encodedURL string, stopwordfunc ...func(string) bool) []string {
+	encodedURLLower := strings.ToLower(encodedURL)
+	var result []string
+
+	// check if url needs unescaping
+	if stringContainsByteChar(encodedURLLower, '%') {
+		decodedURL, err := url.QueryUnescape(encodedURLLower)
+		if err != nil {
+			escapedEncodedURL := url.QueryEscape(encodedURL)
+			decodedURL, err = url.QueryUnescape(escapedEncodedURL)
+		}
+
+		if err != nil {
+			return []string{}
+		}
+
+		result = filterStopWords(tokenizeV3(decodedURL), stopwordfunc...)
+	} else {
+		result = filterStopWords(tokenizeV3(encodedURLLower), stopwordfunc...)
+	}
+
+	return result
+}
+
+// TokenizeFastV3 splits URL to host and path parts and tokenize path and host part
+// all terms are returned in lower case
+func TokenizeFastV3(encodedURL string, stopwordfunc ...func(string) bool) []string {
+	urlLower := strings.ToLower(encodedURL)
+	result := tokenizeV3(urlLower)
+	if len(stopwordfunc) > 0 {
+		result = filterStopWords(result, stopwordfunc[0])
+	}
+	return result
 }
 
 //TokenizeV2 splits URL to host and path parts and tokenize path and host part
@@ -63,6 +118,71 @@ func TokenizeV1(url string, stopwordfunc ...func(string) bool) []string {
 	result := filterStopWords(tokenizeV1(path), stopwordfunc...)
 
 	return append(result, host)
+}
+
+func tokenizeV3(str string) []string {
+	// remove protocol
+	startIndex := strings.Index(str, "://")
+	if startIndex < 7 && startIndex > 0 && len(str) > startIndex+3 {
+		startIndex = startIndex + 3
+	} else {
+		startIndex = 0
+	}
+
+	strLen := len(str)
+	lastIndex := strLen - 1
+	result := make([]string, 0, strLen/MinWordSize)
+	start := -1
+	dotCounter := 0
+	isDotCountMode := true
+	domainNameEndIndex := -1
+	domainNameStartIndex := startIndex
+	var b byte
+	for idx := 0; idx < len(str); idx++ {
+		b = str[idx]
+		if idx < startIndex {
+			continue
+		}
+
+		if isByteAllowed(b, isDotCountMode) {
+			if start == -1 {
+				start = idx
+			}
+			if idx == lastIndex && ((lastIndex-start+1) >= MinWordSize || isDotCountMode) {
+				result = append(result, str[start:strLen])
+			}
+		} else if ((idx-start) >= MinWordSize || isDotCountMode) && start > -1 {
+			result = append(result, str[start:idx])
+			start = -1
+		} else {
+			start = -1
+		}
+		if b == '/' && isDotCountMode {
+			isDotCountMode = false
+			domainNameEndIndex = idx
+			dotCounter = len(result) - 1
+		}
+
+		if b == '?' { // skip query params
+			break
+		}
+	}
+
+	if isDotCountMode {
+		dotCounter = len(result) - 1
+		domainNameEndIndex = len(str)
+	}
+
+	if dotCounter > 0 && len(result) > 1 {
+		result = append(result[:(dotCounter-1)], result[dotCounter+1:]...)
+		if domainNameEndIndex-domainNameStartIndex > 3 { // if domain name is longer than 3 chars
+			for len(str) > domainNameStartIndex && str[domainNameStartIndex] == '.' {
+				domainNameStartIndex++
+			}
+			result = append(result, str[domainNameStartIndex:domainNameEndIndex])
+		}
+	}
+	return result
 }
 
 func tokenizeV2(str string) []string {

--- a/tokenizer/tokenizer_test.go
+++ b/tokenizer/tokenizer_test.go
@@ -86,34 +86,58 @@ func Test_URLTokenizerWithWrongEscapedChars2(t *testing.T) {
 	}, result)
 }
 func Test_URLTokenizerWithWrongHostEscapedChars(t *testing.T) {
-	result := TokenizeV2("http://..example.com/something")
+	result := TokenizeV3("http://..example.com/something")
 	assert.Equal(t, []string{"something", "example.com"}, result)
 }
 
 func Test_URLTokenizerWithCapitalChars(t *testing.T) {
 	DefaultStopWordFunc = IsGermanStopWord
-	result := TokenizeV2("mailto://www.Subdomain.example.com/HSV-fussbal%3asome/a")
+	result := TokenizeV3("mailto://www.Subdomain.example.com/HSV-fussbal%3asome/a")
 	assert.ElementsMatch(t, []string{"subdomain", "hsv", "fussbal", "some", "www.subdomain.example.com"}, result)
 }
 
 func Test_URLWithoutHTTP(t *testing.T) {
-	result := TokenizeV2("www.Subdomain.example.com")
+	result := TokenizeV3("www.Subdomain.example.com")
 	assert.ElementsMatch(t, []string{"subdomain", "www.subdomain.example.com"}, result)
 }
 
 func Test_URLWithoutHTTPAndWithoutSubdomain(t *testing.T) {
-	result := TokenizeV2("www.example.com")
+	result := TokenizeV3("www.example.com")
 	assert.ElementsMatch(t, []string{"www.example.com"}, result)
 }
 
 func Test_URLWithoutHTTPAndSubdomain(t *testing.T) {
-	result := TokenizeV2("sport.fussball.example.com")
+	result := TokenizeV3("sport.fussball.example.com")
 	assert.ElementsMatch(t, []string{"sport", "fussball", "sport.fussball.example.com"}, result)
 }
 
 func Test_URLWithoutHTTPButWithPath(t *testing.T) {
-	result := TokenizeV2("www.ironsrc.com/sports")
+	result := TokenizeV3("www.ironsrc.com/sports")
 	assert.ElementsMatch(t, []string{"sports", "www.ironsrc.com"}, result)
+}
+
+func BenchmarkEscapedURLTokenizerV3(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		TokenizeV3("http://example.com/path/sport/hsv-fussball?bla=1&escaped=%2C%2C%3A%3A%3B%3B")
+	}
+}
+
+func BenchmarkURLTokenizerV3(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		TokenizeV3("http://example.com/path/sport/hsv-fussball?bla=1")
+	}
+}
+
+func BenchmarkURLTokenizerV3Fast(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		TokenizeFastV3("http://example.com/path/sport/hsv-fussball?bla=1")
+	}
+}
+
+func BenchmarkEscapedURLTokenizerV2(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		TokenizeV2("http://example.com/path/sport/hsv-fussball?bla=1&escaped=%2C%2C%3A%3A%3B%3B")
+	}
 }
 
 func BenchmarkURLTokenizerV2(b *testing.B) {
@@ -125,6 +149,12 @@ func BenchmarkURLTokenizerV2(b *testing.B) {
 func BenchmarkURLTokenizerV2Fast(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		TokenizeFastV2("http://example.com/path/sport/hsv-fussball?bla=1")
+	}
+}
+
+func BenchmarkEscapedURLTokenizerV1(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		TokenizeV2("http://example.com/path/sport/hsv-fussball?bla=1&escaped=%2C%2C%3A%3A%3B%3B")
 	}
 }
 
@@ -142,5 +172,11 @@ func BenchmarkTokenizerV1(b *testing.B) {
 func BenchmarkTokenizerV2(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		tokenizeV2("http://example.com/path/sport/hsv-fussball?bla=1")
+	}
+}
+
+func BenchmarkTokenizerV3(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		tokenizeV3("http://example.com/path/sport/hsv-fussball?bla=1")
 	}
 }


### PR DESCRIPTION
It's more like an V2.5, but Go doesn't allow dots within the function names ... so here we are with an V3. Feel free to use these small changes into the existing V2 ... but for better showing of the performance increase, I left it in for now.

```bash
~ go test ./... -bench=. -test.benchmem
goos: linux
goarch: amd64
pkg: github.com/emetriq/gourltokenizer/tokenizer
cpu: AMD Ryzen 7 3700X 8-Core Processor             
BenchmarkEscapedURLTokenizerV3-16        1271954               935.8 ns/op           464 B/op          3 allocs/op
BenchmarkURLTokenizerV3-16               2607987               457.4 ns/op           256 B/op          1 allocs/op
BenchmarkURLTokenizerV3Fast-16           4605972               248.3 ns/op           256 B/op          1 allocs/op
BenchmarkEscapedURLTokenizerV2-16        1234116               959.0 ns/op           464 B/op          3 allocs/op
BenchmarkURLTokenizerV2-16               2165749               552.2 ns/op           256 B/op          1 allocs/op
BenchmarkURLTokenizerV2Fast-16           4374403               272.5 ns/op           256 B/op          1 allocs/op
BenchmarkEscapedURLTokenizerV1-16        1246105               963.0 ns/op           464 B/op          3 allocs/op
BenchmarkURLTokenizerV1-16               1668098               718.9 ns/op           272 B/op          2 allocs/op
BenchmarkTokenizerV1-16                  6767202               169.8 ns/op           256 B/op          1 allocs/op
BenchmarkTokenizerV2-16                  5556195               214.9 ns/op           256 B/op          1 allocs/op
BenchmarkTokenizerV3-16                  6243402               186.7 ns/op           256 B/op          1 allocs/op
PASS
ok      github.com/emetriq/gourltokenizer/tokenizer     18.833s

~ go test ./...
ok      github.com/emetriq/gourltokenizer/tokenizer     0.002s
```

Added an [..]Escaped[..] benchmark, because most performance profits come up, if the given URL doesn't contain any escaped parts. Apart from that, using a byte instead of a rune gives us some performance increase, but results in only accepting the ASCII chars... but since it's already filtering out anything else than a-z, it shouldn't have an impact.